### PR TITLE
fix: correct typo certficate -> certificate

### DIFF
--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -21,7 +21,7 @@ func CreateAdminCerts() {
 		PrivateKeyOutPath: config.LlmDKeyFile,
 	})
 	if err != nil {
-		fmt.Printf("Unable to generate CA certficate :%v\n", err)
+		fmt.Printf("Unable to generate CA certificate :%v\n", err)
 		return
 	}
 }


### PR DESCRIPTION
## Summary
- Fixed typo in `pkg/admin/admin.go`: `certficate` → `certificate`

## Issue
Fixes #29

## Testing
Verified the typo was present and fixed with `grep -r certficate` showing 0 results after fix.